### PR TITLE
feat: add new consumer expectation not present in provider oas

### DIFF
--- a/cypress/fixtures/product.json
+++ b/cypress/fixtures/product.json
@@ -1,1 +1,1 @@
-{"id":"09","type":"CREDIT_CARD","name":"Gem Visa","version":"v1","price":99.99}
+{"id":"09","type":"CREDIT_CARD","name":"Gem Visa","version":"v1","price":99.99,"foo":"bar"}

--- a/cypress/fixtures/products.json
+++ b/cypress/fixtures/products.json
@@ -1,23 +1,26 @@
 [
-    {
-        "id": "09",
-        "type": "CREDIT_CARD",
-        "name": "Gem Visa",
-        "version": "v1",
-        "price": 99.99
-    },
-    {
-        "id": "10",
-        "type": "CREDIT_CARD",
-        "name": "28 Degrees",
-        "version": "v1",
-        "price": 49.49
-    },
-    {
-        "id": "11",
-        "type": "PERSONAL_LOAN",
-        "name": "MyFlexiPay",
-        "version": "v2",
-        "price": 16.5
-    }
+  {
+    "id": "09",
+    "type": "CREDIT_CARD",
+    "name": "Gem Visa",
+    "version": "v1",
+    "price": 99.99,
+    "foo": "bar"
+  },
+  {
+    "id": "10",
+    "type": "CREDIT_CARD",
+    "name": "28 Degrees",
+    "version": "v1",
+    "price": 49.49,
+    "foo": "bar"
+  },
+  {
+    "id": "11",
+    "type": "PERSONAL_LOAN",
+    "name": "MyFlexiPay",
+    "version": "v2",
+    "price": 16.5,
+    "foo": "bar"
+  }
 ]


### PR DESCRIPTION
Adds a breaking change for our consumer, by introducing a field that does not exist in our provider oas.

**_Caveats_**  

This example shows adding a field, to a Cypress fixture file which is encoded into a Pact file at the end of the Cypress test. 

As you can see from the pull request, the new field `foo` is not being used in the consumer code at all.

Be aware of this and ensure your mocks are in sync with your consumer code, so you only encode into the Pact file, fields that your consumer depends on.

This is where the beauty of contract testing lies, as you give a provider an up-to-date view of exactly the consumers requirements.

We could easily remove the `version` field, as that is not used in our consumer client code at all, and keeps our mocks lean.
